### PR TITLE
Add space after symbol_cond in all cases

### DIFF
--- a/clweather.py
+++ b/clweather.py
@@ -261,7 +261,7 @@ else:
         else: print(symbol_clk + ' ' + symbol_cond + ' ' + tempForecast + u'\u00b0' + 'C in ' + cityForecast)
     else:
         if args.imperial:
-            print(symbol_clk + ' ' + symbol_cond + tempForecast + u'\ue341')
-        else: print(symbol_clk + ' ' + symbol_cond + tempForecast + u'\ue339')
+            print(symbol_clk + ' ' + symbol_cond + ' ' + tempForecast + u'\ue341')
+        else: print(symbol_clk + ' ' + symbol_cond + ' ' + tempForecast + u'\ue339')
 
 # EOF ${SCR_DIR}/clweather.py ------------------------------


### PR DESCRIPTION
For non-monospaced fonts, a space is required to render properly. This change keeps it consistent with the case when place is requested.